### PR TITLE
feat: --reasoning-effort オプションを追加

### DIFF
--- a/Qx/Commands/CommandRegistry.cs
+++ b/Qx/Commands/CommandRegistry.cs
@@ -9,6 +9,7 @@ namespace Qx.Commands;
 internal static class CommandRegistry
 {
     private static readonly string[] ValidSearchContextSizes = { "low", "medium", "high" };
+    private static readonly string[] ValidReasoningEfforts = { "low", "medium", "high" };
 
     public static RootCommand CreateRootCommand(IServiceProvider serviceProvider)
     {
@@ -76,6 +77,12 @@ internal static class CommandRegistry
         };
         searchContextSizeOption.Aliases.Add("-s");
 
+        var reasoningEffortOption = new Option<string>("--reasoning-effort")
+        {
+            Description = "Reasoning effort level for response generation (low, medium, high)"
+        };
+        reasoningEffortOption.Aliases.Add("-r");
+
         var verboseOption = new Option<bool>("--verbose")
         {
             Description = "Show detailed response information in JSON format"
@@ -101,6 +108,7 @@ internal static class CommandRegistry
         rootCommand.Options.Add(webSearchOption);
         rootCommand.Options.Add(noWebSearchOption);
         rootCommand.Options.Add(searchContextSizeOption);
+        rootCommand.Options.Add(reasoningEffortOption);
         rootCommand.Options.Add(functionsOption);
         rootCommand.Options.Add(noFunctionsOption);
         rootCommand.Options.Add(verboseOption);
@@ -194,6 +202,7 @@ internal static class CommandRegistry
                 Console.WriteLine("  -w, --web-search             Enable web search for more comprehensive answers [default: enabled]");
                 Console.WriteLine("  --no-web-search              Disable web search (use model knowledge only)");
                 Console.WriteLine("  -s, --search-context-size <size>  Context size for web search (low, medium, high) [default: medium]");
+                Console.WriteLine("  -r, --reasoning-effort <effort>  Reasoning effort level (low, medium, high)");
                 Console.WriteLine("  -f, --functions              Enable function calling (GetCurrentTime, GetWeather, CalculateExpression) [default: enabled]");
                 Console.WriteLine("  --no-functions               Disable function calling");
                 Console.WriteLine("  -v, --verbose                Show detailed response information in JSON format");
@@ -229,11 +238,19 @@ internal static class CommandRegistry
 
             bool verbose = parseResult.GetValue(verboseOption);
             string? searchContextSize = parseResult.GetValue(searchContextSizeOption);
+            string? reasoningEffort = parseResult.GetValue(reasoningEffortOption);
 
             // Validate search context size
             if (!string.IsNullOrEmpty(searchContextSize) && !ValidSearchContextSizes.Contains(searchContextSize))
             {
                 Console.Error.WriteLine($"Error: Invalid search-context-size value '{searchContextSize}'. Must be 'low', 'medium', or 'high'.");
+                return 1;
+            }
+
+            // Validate reasoning effort
+            if (!string.IsNullOrEmpty(reasoningEffort) && !ValidReasoningEfforts.Contains(reasoningEffort))
+            {
+                Console.Error.WriteLine($"Error: Invalid reasoning-effort value '{reasoningEffort}'. Must be 'low', 'medium', or 'high'.");
                 return 1;
             }
 
@@ -247,7 +264,8 @@ internal static class CommandRegistry
                 enableWebSearch,
                 enableFunctionCalling,
                 verbose,
-                searchContextSize).ConfigureAwait(false)
+                searchContextSize,
+                reasoningEffort).ConfigureAwait(false)
             ).GetAwaiter().GetResult();
 
             return 0;

--- a/Qx/Handlers/QueryCommandHandler.cs
+++ b/Qx/Handlers/QueryCommandHandler.cs
@@ -15,7 +15,7 @@ internal sealed class QueryCommandHandler
         _openAIService = openAIService ?? throw new ArgumentNullException(nameof(openAIService));
     }
 
-    public async Task<int> HandleAsync(string[] promptParts, string model, string? outputPath, double temperature, int? maxTokens, bool enableWebSearch = true, bool enableFunctionCalling = true, bool verbose = false, string? searchContextSize = null)
+    public async Task<int> HandleAsync(string[] promptParts, string model, string? outputPath, double temperature, int? maxTokens, bool enableWebSearch = true, bool enableFunctionCalling = true, bool verbose = false, string? searchContextSize = null, string? reasoningEffort = null)
     {
         string prompt = string.Join(" ", promptParts ?? Array.Empty<string>());
 
@@ -53,7 +53,8 @@ internal sealed class QueryCommandHandler
                 enableWebSearch,
                 enableFunctionCalling,
                 verbose,
-                searchContextSize).ConfigureAwait(false);
+                searchContextSize,
+                reasoningEffort).ConfigureAwait(false);
 
             // Show verbose output if requested
             if (verbose && responseDetails != null)

--- a/Qx/Services/IOpenAIService.cs
+++ b/Qx/Services/IOpenAIService.cs
@@ -16,8 +16,9 @@ internal interface IOpenAIService
     /// <param name="enableFunctionCalling">Whether to enable function calling</param>
     /// <param name="showFunctionCalls">Whether to show function call indicators in output</param>
     /// <param name="searchContextSize">Context size for web search (low, medium, high)</param>
+    /// <param name="reasoningEffort">Reasoning effort level (low, medium, high)</param>
     /// <returns>The response from OpenAI</returns>
-    Task<string> GetCompletionAsync(string prompt, string model, double temperature, int? maxTokens, bool enableWebSearch = false, bool enableFunctionCalling = false, bool showFunctionCalls = false, string? searchContextSize = null);
+    Task<string> GetCompletionAsync(string prompt, string model, double temperature, int? maxTokens, bool enableWebSearch = false, bool enableFunctionCalling = false, bool showFunctionCalls = false, string? searchContextSize = null, string? reasoningEffort = null);
 
     /// <summary>
     /// Get a completion from OpenAI with detailed response information
@@ -30,6 +31,7 @@ internal interface IOpenAIService
     /// <param name="enableFunctionCalling">Whether to enable function calling</param>
     /// <param name="showFunctionCalls">Whether to show function call indicators in output</param>
     /// <param name="searchContextSize">Context size for web search (low, medium, high)</param>
+    /// <param name="reasoningEffort">Reasoning effort level (low, medium, high)</param>
     /// <returns>A tuple of response text and detailed response object</returns>
-    Task<(string response, ResponseDetails? details)> GetCompletionWithDetailsAsync(string prompt, string model, double temperature, int? maxTokens, bool enableWebSearch = false, bool enableFunctionCalling = false, bool showFunctionCalls = false, string? searchContextSize = null);
+    Task<(string response, ResponseDetails? details)> GetCompletionWithDetailsAsync(string prompt, string model, double temperature, int? maxTokens, bool enableWebSearch = false, bool enableFunctionCalling = false, bool showFunctionCalls = false, string? searchContextSize = null, string? reasoningEffort = null);
 }

--- a/Qx/Services/OpenAIService.cs
+++ b/Qx/Services/OpenAIService.cs
@@ -38,7 +38,7 @@ internal sealed class OpenAIService : IOpenAIService
     /// Get a completion from OpenAI with specific parameters
     /// </summary>
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only
-    public async Task<string> GetCompletionAsync(string prompt, string model, double temperature, int? maxTokens, bool enableWebSearch = false, bool enableFunctionCalling = false, bool showFunctionCalls = false, string? searchContextSize = null)
+    public async Task<string> GetCompletionAsync(string prompt, string model, double temperature, int? maxTokens, bool enableWebSearch = false, bool enableFunctionCalling = false, bool showFunctionCalls = false, string? searchContextSize = null, string? reasoningEffort = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(prompt);
         ArgumentException.ThrowIfNullOrWhiteSpace(model);
@@ -54,6 +54,21 @@ internal sealed class OpenAIService : IOpenAIService
             Temperature = (float)temperature,
             MaxOutputTokenCount = maxTokens
         };
+
+        // Add reasoning options if specified
+        if (!string.IsNullOrEmpty(reasoningEffort))
+        {
+            options.ReasoningOptions = new ResponseReasoningOptions
+            {
+                ReasoningEffortLevel = reasoningEffort.ToUpperInvariant() switch
+                {
+                    "LOW" => ResponseReasoningEffortLevel.Low,
+                    "MEDIUM" => ResponseReasoningEffortLevel.Medium,
+                    "HIGH" => ResponseReasoningEffortLevel.High,
+                    _ => ResponseReasoningEffortLevel.Medium
+                }
+            };
+        }
 
         // Add web search tool
         if (enableWebSearch)
@@ -162,7 +177,7 @@ internal sealed class OpenAIService : IOpenAIService
     /// Get a completion from OpenAI with detailed response information
     /// </summary>
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only
-    public async Task<(string response, ResponseDetails? details)> GetCompletionWithDetailsAsync(string prompt, string model, double temperature, int? maxTokens, bool enableWebSearch = false, bool enableFunctionCalling = false, bool showFunctionCalls = false, string? searchContextSize = null)
+    public async Task<(string response, ResponseDetails? details)> GetCompletionWithDetailsAsync(string prompt, string model, double temperature, int? maxTokens, bool enableWebSearch = false, bool enableFunctionCalling = false, bool showFunctionCalls = false, string? searchContextSize = null, string? reasoningEffort = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(prompt);
         ArgumentException.ThrowIfNullOrWhiteSpace(model);
@@ -178,6 +193,21 @@ internal sealed class OpenAIService : IOpenAIService
             Temperature = (float)temperature,
             MaxOutputTokenCount = maxTokens
         };
+
+        // Add reasoning options if specified
+        if (!string.IsNullOrEmpty(reasoningEffort))
+        {
+            options.ReasoningOptions = new ResponseReasoningOptions
+            {
+                ReasoningEffortLevel = reasoningEffort.ToUpperInvariant() switch
+                {
+                    "LOW" => ResponseReasoningEffortLevel.Low,
+                    "MEDIUM" => ResponseReasoningEffortLevel.Medium,
+                    "HIGH" => ResponseReasoningEffortLevel.High,
+                    _ => ResponseReasoningEffortLevel.Medium
+                }
+            };
+        }
 
         // Add web search tool
         if (enableWebSearch)


### PR DESCRIPTION
## Summary
- `-r, --reasoning-effort` オプションを追加し、AI推論の努力レベルを指定可能に
- 指定可能な値: `low`, `medium`, `high`
- OpenAI APIのReasoningOptionsを使用して推論努力レベルを制御

## 実装内容
- コマンドラインオプションの追加（`-r` エイリアス付き）
- バリデーション処理（low/medium/high のみ受け付け）
- OpenAIService.csでResponseReasoningOptionsの実装
- オプション未指定時はReasoningOptionsを設定しない（デフォルト動作）

## 技術的詳細
- ResponseCreationOptionsにReasoningOptionsプロパティを設定
- ResponseReasoningEffortLevel列挙型を使用して値を設定
- CA1308警告を修正（ToUpperInvariantを使用）

## Test plan
- [x] ビルドが成功することを確認
- [x] 既存テスト（89個）がパスすることを確認
- [x] ヘルプテキストに新しいオプションが表示されることを確認
- [x] 無効な値を指定した場合にエラーメッセージが表示されることを確認
- [x] 有効な値（low/medium/high）を指定して正常に動作することを確認
- [x] 短縮オプション `-r` が正常に動作することを確認